### PR TITLE
Numpy Downgrade Version to 1.22.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pip
   - pip:
       - otter-grader==4.3.2
+      - numpy==1.22.0
       - datascience==0.17.5
       # Allow users to download their home directories
       - jupyter-tree-download


### PR DESCRIPTION
The 1.22.0 version of numpy is needed to run lab 10 on the Data 8 Spring 2022 notebooks used by cloudbank cluster users. This makes sense since the notebooks were created with this version of numpy