### PR TITLE
nbformat downgrade 5.3.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,6 @@ dependencies:
   - pip:
       - otter-grader==4.3.2
       - datascience==0.17.5
+      - nbformat==5.3.0
       # Allow users to download their home directories
       - jupyter-tree-download


### PR DESCRIPTION
This is a temporary downgrade to immediately fix the rendering warning/error breaking the export cell on our notebooks. The problem is that one or more of the notebook cells do not have the mandatory "id" field. I will be updating the notebooks themselves next week and we will figure out a plan from there.